### PR TITLE
Updated header

### DIFF
--- a/invoicia_frontend/src/components/Header/header.js
+++ b/invoicia_frontend/src/components/Header/header.js
@@ -80,6 +80,26 @@ const Header = () => {
                     </NavLink>
                   </li>
                 )
+              ) : item.title === "Home" || item.title === "All Invoices" ? (
+                isLoggedIn && (
+                  <li key={index} className="nav-item">
+                    <NavLink
+                      exact
+                      to={item.url}
+                      activeClassName="active"
+                      className="nav-links"
+                      onClick={handleClick}
+                    >
+                      {item.title}
+                    </NavLink>
+                  </li>
+                )
+              ) : item.title === "Home" || item.title === "All Invoices" ? (
+                !isLoggedIn && (
+                  <li key={index} className="nav-item">
+                    
+                  </li>
+                )
               ) : (
                 <li key={index} className="nav-item">
                   <NavLink


### PR DESCRIPTION
# Related Issue
- #17 

# Proposed Changes
- Only navigation tabs 'signup' and 'login' will be visible untill user hasn't logged in
- Other navigation tabs will be visible after user has been logged in.

# Checklist
- [x] File (js/css/other) modified

# Screenshot of feature
#### Before Login:
![image](https://user-images.githubusercontent.com/78429106/147516021-2970bbc9-1fbc-4472-825c-b6a014f49ae7.png)
#### After Login:
![image](https://user-images.githubusercontent.com/78429106/147516117-baca32d3-be0e-4fca-9b21-d3aa81951bec.png)


